### PR TITLE
security(rc.8): normalize timing on GET /v1/turns/:turn_id 404 paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 
 ## [Unreleased]
 
+### Security
+
+- **Agent API: `GET /v1/turns/:turn_id` 404 paths take a uniform DB
+  round-trip.** Previously a malformed (non-integer) turn id was
+  rejected before the DB lookup, while a valid-integer-but-not-yours id
+  paid for the lookup + permission check. The two branches were
+  distinguishable via response timing, leaking whether a guessed id was
+  syntactically plausible against the caller's token. The handler now
+  always issues the DB query (non-integer / out-of-range ids coerce to
+  a sentinel that misses cleanly), so the timing profile is uniform
+  across malformed, out-of-range, and valid-but-not-yours.
+
 ## [1.0.0-rc.6] - 2026-04-21
 
 ### Changed
@@ -88,11 +100,11 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
   `TORANA_TOKEN` env, and named profiles (see below). Stable exit codes
   (0/1/2/3/4/5/6/7) for scripting. See [docs/cli.md](docs/cli.md).
 - **CLI profile store.** `torana config init | add-profile | list-profiles |
-  remove-profile | show` manages a TOML file at
+remove-profile | show` manages a TOML file at
   `$XDG_CONFIG_HOME/torana/config.toml` (mode 0600). Every agent-api
   subcommand resolves credentials with the precedence
   `flag > env > --profile NAME > default profile`. `torana doctor
-  --profile NAME` runs the R001..R003 remote probes against the resolved
+--profile NAME` runs the R001..R003 remote probes against the resolved
   server.
 - **`--file @-` on `torana ask` / `torana inject`.** Reads attachment bytes
   from stdin with magic-byte MIME detection (PNG, JPEG, GIF, WebP, PDF;
@@ -100,7 +112,7 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
   a second `@-` on the same call is a usage error.
 - **Skills + Codex plugin.** `skills/torana-ask/SKILL.md` and
   `skills/torana-inject/SKILL.md` ship with the package. `torana skills
-  install --host=claude|codex` copies them into
+install --host=claude|codex` copies them into
   `$CLAUDE_CONFIG_DIR/skills` / `$XDG_DATA_HOME/agents/skills` (default
   refuses on divergence; `--force` overwrites). `codex-plugin/` contains
   a manifest + marketplace.json entry for one-line Codex install; a

--- a/src/agent-api/handlers/turns.ts
+++ b/src/agent-api/handlers/turns.ts
@@ -1,11 +1,14 @@
 // GET /v1/turns/:turn_id handler.
 //
 // Auth order (timing-attack-safe — tasks/impl-agent-api.md §6.2):
-//   1. Parse turn_id from path. Malformed → 404 turn_not_found.
+//   1. Parse turn_id from path. Non-integer / out-of-range ids are
+//      coerced to a sentinel (0) that will never match a row — we still
+//      run the DB lookup so timing doesn't distinguish "malformed id"
+//      from "valid id you don't own".
 //   2. Authenticate first (before any DB lookup) so latency doesn't leak
 //      whether the id exists.
-//   3. Lookup turn. If missing / telegram-origin / another caller's turn,
-//      return the same 404 turn_not_found.
+//   3. Lookup turn (always). If missing / telegram-origin / another
+//      caller's turn, return the same 404 turn_not_found.
 //   4. Authorize: ask-turn needs scope "ask"; send-turn needs "send".
 //   5. Body by status.
 
@@ -18,15 +21,17 @@ const TURN_RESULT_TTL_MS = 24 * 60 * 60 * 1000;
 
 export function handleGetTurn(deps: AgentApiDeps): RouteHandler {
   return async (req, params) => {
-    const turnId = Number(params.turn_id);
-    if (!Number.isInteger(turnId) || turnId < 1) {
-      return errorResponse("turn_not_found");
-    }
+    const turnIdRaw = Number(params.turn_id);
+    // Non-integer / out-of-range ids are coerced to 0 so the DB lookup
+    // still runs and misses cleanly. This keeps the timing profile
+    // uniform across malformed, out-of-range, and valid-but-not-yours.
+    const lookupId =
+      Number.isInteger(turnIdRaw) && turnIdRaw >= 1 ? turnIdRaw : 0;
 
     const a = authenticate(deps.tokens, req.headers.get("Authorization"));
     if ("kind" in a) return mapAuthFailure(a);
 
-    const turn = deps.db.getTurnExtended(turnId);
+    const turn = deps.db.getTurnExtended(lookupId);
     if (
       !turn ||
       !turn.agent_api_token_name ||
@@ -34,6 +39,7 @@ export function handleGetTurn(deps: AgentApiDeps): RouteHandler {
     ) {
       return errorResponse("turn_not_found");
     }
+    const turnId = turn.id;
 
     const needed: "ask" | "send" =
       turn.source === "agent_api_ask" ? "ask" : "send";

--- a/test/security/agent-api/authz.enumeration-resistance.test.ts
+++ b/test/security/agent-api/authz.enumeration-resistance.test.ts
@@ -136,4 +136,77 @@ describe("§12.5.2 authz.enumeration-resistance", () => {
     expect((await rValid.json()).error).toBe("turn_not_found");
     expect((await rMalformed.json()).error).toBe("turn_not_found");
   });
+
+  test("malformed / out-of-range / valid-not-yours all hit the DB lookup", async () => {
+    // Timing-uniformity invariant: every 404 path must take the DB
+    // round-trip, otherwise the malformed branch is fast-pathed and an
+    // attacker can distinguish "id you don't own" from "id that can't
+    // exist" by latency. Hard to assert wall-clock timing reliably, so
+    // we instead spy on getTurnExtended and require it was called for
+    // every authenticated 404 case.
+    h = startHarness({ tokens: [attacker, victim] });
+
+    const lookupCalls: unknown[] = [];
+    const origLookup = h.db.getTurnExtended.bind(h.db);
+    h.db.getTurnExtended = (id: number) => {
+      lookupCalls.push(id);
+      return origLookup(id);
+    };
+
+    // (a) Valid integer id owned by another caller.
+    const victimTurnId = h.db.insertAskTurn({
+      botId: "bot1",
+      tokenName: "victim",
+      sessionId: "v-sess-spy",
+      textPreview: "secret",
+      attachmentPaths: [],
+    });
+    // Reset the spy after the insert (which doesn't go through getTurnExtended,
+    // but be defensive in case future helpers do).
+    lookupCalls.length = 0;
+
+    const rValidNotYours = await fetch(`${h.base}/v1/turns/${victimTurnId}`, {
+      headers: { Authorization: `Bearer ${attackerSecret}` },
+    });
+
+    // (b) Out-of-range valid integer (no row will match).
+    const rOutOfRange = await fetch(`${h.base}/v1/turns/9999999999`, {
+      headers: { Authorization: `Bearer ${attackerSecret}` },
+    });
+
+    // (c) Malformed (non-integer) id.
+    const rMalformed = await fetch(`${h.base}/v1/turns/not-a-number`, {
+      headers: { Authorization: `Bearer ${attackerSecret}` },
+    });
+
+    // (d) Negative integer id.
+    const rNegative = await fetch(`${h.base}/v1/turns/-1`, {
+      headers: { Authorization: `Bearer ${attackerSecret}` },
+    });
+
+    // All four should look identical to a caller.
+    expect(rValidNotYours.status).toBe(404);
+    expect(rOutOfRange.status).toBe(404);
+    expect(rMalformed.status).toBe(404);
+    expect(rNegative.status).toBe(404);
+
+    const bodies = await Promise.all([
+      rValidNotYours.text(),
+      rOutOfRange.text(),
+      rMalformed.text(),
+      rNegative.text(),
+    ]);
+    // Byte-identical bodies — no leak of which branch produced the 404.
+    expect(new Set(bodies).size).toBe(1);
+    expect(JSON.parse(bodies[0]!).error).toBe("turn_not_found");
+
+    // The DB was queried in all four cases. This is the timing-
+    // uniformity guarantee — every authenticated 404 path takes the
+    // round-trip, not just the ones with a syntactically valid id.
+    expect(lookupCalls.length).toBe(4);
+    // Malformed / negative coerce to 0 (or any sentinel that misses);
+    // the only requirement is the lookup was issued at all.
+    expect(lookupCalls).toContain(victimTurnId);
+    expect(lookupCalls).toContain(9999999999);
+  });
 });


### PR DESCRIPTION
## Summary

- Fix timing-distinguishability between the two 404 paths in `GET /v1/turns/:turn_id`. Previously a malformed (non-integer) id was rejected before the DB lookup, while a valid-integer-but-not-yours id paid for the lookup + permission check. The two were observably different in response time, leaking whether a guessed id was syntactically plausible against the caller's token.
- The handler now coerces non-integer / out-of-range ids to a sentinel that never matches a row, then always issues the DB query and applies the permission filter. Timing profile is uniform across malformed, out-of-range, and valid-but-not-yours.
- Adds a §12.5.2 test that spies on `getTurnExtended` and asserts (a) the lookup runs for every authenticated 404 path, and (b) all four bodies (valid-not-yours / out-of-range / malformed / negative) are byte-identical.

This is the P2 deferred item #5 from the rc.7 security review (`tasks/rc.7-security-hardening.md`). Branched from `main` so it can land independently for rc.8.

## Test plan

- [x] `bun run typecheck`
- [x] `bun test` — 1143 pass / 13 skip / 0 fail / 2886 expect calls
- [x] `bun test test/security/agent-api/authz.enumeration-resistance.test.ts` — 5 pass (one new test)
- [x] `bun test test/agent-api/router.test.ts` — 13 pass (existing `malformed id → 404` case still passes through new code path)
- [ ] Manual timing sanity-check (response wall-clock now indistinguishable across the four 404 variants — covered logically by the spy assertion; left optional for rc.8 cut)

🤖 Generated with [Claude Code](https://claude.com/claude-code)