### PR TITLE
security(rc.8): canonical detail for agent-API error responses (P2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,24 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 
 ## [Unreleased]
 
+### Security
+
+- **Agent API: stop echoing raw exception text into 4xx/5xx response
+  bodies.** `POST /v1/bots/:id/send` and the multipart parser used by
+  both `/send` and `/ask` previously forwarded `err.message` from
+  `req.formData()`, `JSON.parse`, `insertSendTurn`, and `writeFile` into
+  the response `detail`/`message` field. The body is not a safe channel
+  for internal implementation detail: the SQLite layer surfaces column
+  names plus constraint text, the multipart parser surfaces internal
+  boundary state, and `writeFile` errors carry absolute paths and errno
+  detail. An authenticated low-privilege caller probing for
+  schema/SQL/path information could harvest it from a 4xx/5xx without
+  any further capability. Caught exceptions are now mapped to canonical
+  detail strings (`malformed multipart body`, `attachment write failed`,
+  default `internal error` for 500s); the raw `err.message` and stack
+  are logged server-side at warn/error level for ops debugging. No
+  client-visible behaviour change beyond the response body string.
+
 ## [1.0.0-rc.6] - 2026-04-21
 
 ### Changed
@@ -88,11 +106,11 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
   `TORANA_TOKEN` env, and named profiles (see below). Stable exit codes
   (0/1/2/3/4/5/6/7) for scripting. See [docs/cli.md](docs/cli.md).
 - **CLI profile store.** `torana config init | add-profile | list-profiles |
-  remove-profile | show` manages a TOML file at
+remove-profile | show` manages a TOML file at
   `$XDG_CONFIG_HOME/torana/config.toml` (mode 0600). Every agent-api
   subcommand resolves credentials with the precedence
   `flag > env > --profile NAME > default profile`. `torana doctor
-  --profile NAME` runs the R001..R003 remote probes against the resolved
+--profile NAME` runs the R001..R003 remote probes against the resolved
   server.
 - **`--file @-` on `torana ask` / `torana inject`.** Reads attachment bytes
   from stdin with magic-byte MIME detection (PNG, JPEG, GIF, WebP, PDF;
@@ -100,7 +118,7 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
   a second `@-` on the same call is a usage error.
 - **Skills + Codex plugin.** `skills/torana-ask/SKILL.md` and
   `skills/torana-inject/SKILL.md` ship with the package. `torana skills
-  install --host=claude|codex` copies them into
+install --host=claude|codex` copies them into
   `$CLAUDE_CONFIG_DIR/skills` / `$XDG_DATA_HOME/agents/skills` (default
   refuses on divergence; `--force` overwrites). `codex-plugin/` contains
   a manifest + marketplace.json entry for one-line Codex install; a

--- a/src/agent-api/attachments.ts
+++ b/src/agent-api/attachments.ts
@@ -119,7 +119,11 @@ export async function parseMultipartRequest(
 
   const contentType = req.headers.get("content-type") ?? "";
   if (!contentType.toLowerCase().includes("multipart/form-data")) {
-    return { kind: "err", code: "invalid_body", detail: "expected multipart/form-data" };
+    return {
+      kind: "err",
+      code: "invalid_body",
+      detail: "expected multipart/form-data",
+    };
   }
 
   // Early aggregate check via Content-Length (stream-reading with hard abort
@@ -140,10 +144,18 @@ export async function parseMultipartRequest(
   try {
     form = await req.formData();
   } catch (err) {
+    // Log raw parser error server-side; respond with a canonical detail.
+    // Bun's multipart parser surfaces internal boundary/state info in
+    // its messages — not safe to echo into the client response body.
+    log.warn("multipart formData parse failed", {
+      bot_id: botId,
+      request_id: requestId,
+      error: err instanceof Error ? err.message : String(err),
+    });
     return {
       kind: "err",
       code: "invalid_body",
-      detail: err instanceof Error ? err.message : String(err),
+      detail: "malformed multipart body",
     };
   }
 
@@ -258,15 +270,20 @@ export async function parseMultipartRequest(
         detail: err instanceof Error ? err.message : String(err),
       };
     }
+    // Unclassified failure (writeFile EACCES/ENOSPC/EFBIG, magic-byte
+    // mismatch, etc.). Log raw error server-side so ops can debug; respond
+    // with a canonical detail. Filesystem errors carry absolute paths and
+    // errno detail that must not surface to the client.
     log.error("multipart write failed", {
       bot_id: botId,
       request_id: requestId,
       error: err instanceof Error ? err.message : String(err),
+      stack: err instanceof Error ? err.stack : undefined,
     });
     return {
       kind: "err",
       code: "invalid_body",
-      detail: err instanceof Error ? err.message : String(err),
+      detail: "attachment write failed",
     };
   }
 

--- a/src/agent-api/handlers/send.ts
+++ b/src/agent-api/handlers/send.ts
@@ -41,7 +41,16 @@ export function handleSend(deps: SendDeps): AuthedHandler {
     const outcome: { replay: boolean } = { replay: false };
     const resp = await inner(req, params, outcome);
     recordSend(deps.metrics, params.botId, {
-      status: resp.status as 202 | 400 | 401 | 403 | 404 | 429 | 500 | 501 | 503,
+      status: resp.status as
+        | 202
+        | 400
+        | 401
+        | 403
+        | 404
+        | 429
+        | 500
+        | 501
+        | 503,
       replay: outcome.replay,
       durationMs: Date.now() - startMs,
     } as Parameters<typeof recordSend>[2]);
@@ -176,14 +185,16 @@ function handleSendInner(
       });
     } catch (err) {
       await cleanupFiles(attachmentPaths);
+      // Log raw error server-side; never echo the exception text into the
+      // response body. SQLite errors carry column names + constraint detail,
+      // and an authenticated low-privilege caller probing for schema/SQL
+      // info should not be able to learn it from a 500.
       deps.log.error("insertSendTurn failed", {
         bot_id: botId,
         error: err instanceof Error ? err.message : String(err),
+        stack: err instanceof Error ? err.stack : undefined,
       });
-      return errorResponse(
-        "internal_error",
-        err instanceof Error ? err.message : String(err),
-      );
+      return errorResponse("internal_error");
     }
 
     if (insertResult.replay) {

--- a/test/security/agent-api/disclosure.error-body.test.ts
+++ b/test/security/agent-api/disclosure.error-body.test.ts
@@ -101,6 +101,78 @@ describe("§12.5.6 disclosure.error-body", () => {
     const r = errorResponse("internal_error");
     expect(r.status).toBe(500);
     const body = await r.json();
-    expect(body).toEqual({ error: "internal_error", message: "internal error" });
+    expect(body).toEqual({
+      error: "internal_error",
+      message: "internal error",
+    });
+  });
+
+  test("malformed multipart body → 400 with canonical detail, no parser-internal text", async () => {
+    h = startHarness({ tokens: [token] });
+    h.db.upsertUserChat("bot1", "111222333", 555);
+
+    // Declare multipart but send a body that the multipart parser cannot
+    // decode. Bun's parser raises an Error whose message describes its
+    // internal state ("Failed to parse FormData", boundary detail, etc.) —
+    // none of that should reach the client.
+    const r = await fetch(`${h.base}/v1/bots/bot1/send`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${secret}`,
+        "Content-Type":
+          "multipart/form-data; boundary=----not-a-real-boundary-xyz",
+        "Idempotency-Key": "idem-malformed-multipart01",
+      },
+      body: "this is not a multipart body at all",
+    });
+    expect(r.status).toBe(400);
+    const body = (await r.json()) as { error: string; message: string };
+    expect(body.error).toBe("invalid_body");
+    // Canonical detail — fixed string, NOT echoed parser exception text.
+    expect(body.message).toBe("malformed multipart body");
+    // Belt-and-braces: nothing parser-internal slipped through.
+    const s = JSON.stringify(body);
+    expect(s).not.toMatch(/FormData/i);
+    expect(s).not.toMatch(/boundary/i);
+    expect(s).not.toContain("Error:");
+    expect(s).not.toMatch(/\/Users\//);
+    expect(s).not.toMatch(/\.ts:\d+/);
+  });
+
+  test("insertSendTurn throw → 500 with canonical detail, no SQLite text", async () => {
+    h = startHarness({ tokens: [token] });
+    h.db.upsertUserChat("bot1", "111222333", 555);
+    // Drop the `turns` table out from under the cached prepared statement.
+    // insertSendTurnRow will then raise `SQLiteError: no such table: turns`
+    // — exactly the kind of schema-leaking exception text we want to make
+    // sure the handler does NOT echo into the response.
+    h.db.query("DROP TABLE turns").run();
+
+    const r = await fetch(`${h.base}/v1/bots/bot1/send`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${secret}`,
+        "Content-Type": "application/json",
+        "Idempotency-Key": "idem-insert-throws-000001",
+      },
+      body: JSON.stringify({
+        text: "hi",
+        source: "x",
+        user_id: "111222333",
+      }),
+    });
+    expect(r.status).toBe(500);
+    const body = (await r.json()) as { error: string; message: string };
+    expect(body.error).toBe("internal_error");
+    expect(body.message).toBe("internal error");
+    // Belt-and-braces: nothing SQLite/internal slipped through.
+    const s = JSON.stringify(body);
+    expect(s).not.toMatch(/sqlite/i);
+    expect(s).not.toMatch(/database/i);
+    expect(s).not.toMatch(/UNIQUE constraint/i);
+    expect(s).not.toMatch(/no such table/i);
+    expect(s).not.toContain("Error:");
+    expect(s).not.toMatch(/\/Users\//);
+    expect(s).not.toMatch(/\.ts:\d+/);
   });
 });


### PR DESCRIPTION
## Summary

- Stop echoing raw exception text from `req.formData()`, `JSON.parse`, `insertSendTurn`, and `writeFile` into the `/v1/bots/:id/send` and multipart-parser response bodies.
- Map caught exceptions to canonical detail strings (`malformed multipart body`, `attachment write failed`, default `internal error` for 500s); log the raw `err.message` + stack server-side at warn/error level for ops debugging.
- Extends `test/security/agent-api/disclosure.error-body.test.ts` with two end-to-end probes that drive the catch paths and assert the response body never contains SQLite, multipart-parser, or filesystem-path text.

## Why

P2 item #4 from the rc.7 deep-review backlog (see `tasks/rc.7-security-hardening.md` on `rc.7/security-hardening`). The bearer-auth gate doesn't make the response body a safe channel for internal implementation detail — a low-privilege caller probing for schema/SQL/path information should not be able to harvest it from a 4xx/5xx. Branched from `main` so it lands independently of the in-flight `rc.7/security-hardening` cut.

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun run format` — clean (only the four targeted files modified)
- [x] `bun test` — 1144 pass / 0 fail / 13 skip
- [x] New tests:
  - malformed multipart body → 400 with `message === "malformed multipart body"` and no `FormData`/`boundary` text
  - `DROP TABLE turns` mid-flight → 500 with `message === "internal error"` and no `sqlite`/`database`/`UNIQUE constraint`/`no such table` text

🤖 Generated with [Claude Code](https://claude.com/claude-code)