### PR TITLE
security(rc.8): harden attachment writes with O_EXCL+O_NOFOLLOW

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,29 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 
 ## [Unreleased]
 
+### Security
+
+- **Hardened attachment write path against overwrite + symlink races.**
+  `src/core/attachments.ts` now opens the destination file with
+  `O_CREAT | O_EXCL | O_WRONLY | O_NOFOLLOW` instead of the convenience
+  `writeFile()`. Two concrete improvements:
+  - **No overwrite of pre-existing files.** If a file already exists at
+    the derived `<update_id>-<index><ext>` path (rare collisions across
+    restarts/replays, or anything staged by a less-trusted process), the
+    open fails with EEXIST and we retry under a fresh
+    `<update_id>-<index>-<uuid><ext>` name (up to 3 retries). The
+    pre-existing file is left intact.
+  - **Refuses to follow symlinks at the target.** A symlink staged in
+    the attachments directory pointing outside it is rejected with a
+    distinct `ATTACHMENT_SYMLINK_REJECTED` error, logged at `error`
+    level with `bot_id` / `update_id` so ops can investigate. The
+    decoy target is never written through.
+
+  Before: `writeFile(target, bytes)` happily overwrote existing files
+  and silently followed symlinks. After: O_EXCL + O_NOFOLLOW (with an
+  lstat fallback because POSIX gives O_EXCL priority over O_NOFOLLOW
+  when both are set on Linux/macOS).
+
 ## [1.0.0-rc.6] - 2026-04-21
 
 ### Changed
@@ -88,11 +111,11 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
   `TORANA_TOKEN` env, and named profiles (see below). Stable exit codes
   (0/1/2/3/4/5/6/7) for scripting. See [docs/cli.md](docs/cli.md).
 - **CLI profile store.** `torana config init | add-profile | list-profiles |
-  remove-profile | show` manages a TOML file at
+remove-profile | show` manages a TOML file at
   `$XDG_CONFIG_HOME/torana/config.toml` (mode 0600). Every agent-api
   subcommand resolves credentials with the precedence
   `flag > env > --profile NAME > default profile`. `torana doctor
-  --profile NAME` runs the R001..R003 remote probes against the resolved
+--profile NAME` runs the R001..R003 remote probes against the resolved
   server.
 - **`--file @-` on `torana ask` / `torana inject`.** Reads attachment bytes
   from stdin with magic-byte MIME detection (PNG, JPEG, GIF, WebP, PDF;
@@ -100,7 +123,7 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
   a second `@-` on the same call is a usage error.
 - **Skills + Codex plugin.** `skills/torana-ask/SKILL.md` and
   `skills/torana-inject/SKILL.md` ship with the package. `torana skills
-  install --host=claude|codex` copies them into
+install --host=claude|codex` copies them into
   `$CLAUDE_CONFIG_DIR/skills` / `$XDG_DATA_HOME/agents/skills` (default
   refuses on divergence; `--force` overwrites). `codex-plugin/` contains
   a manifest + marketplace.json entry for one-line Codex install; a

--- a/src/core/attachments.ts
+++ b/src/core/attachments.ts
@@ -4,7 +4,9 @@
 // on-disk name or extension (they are attacker-influenced and could contain
 // path separators, NUL bytes, or misleading extensions).
 
-import { mkdir, writeFile, stat, readdir, unlink } from "node:fs/promises";
+import { mkdir, open, stat, lstat, readdir, unlink } from "node:fs/promises";
+import { constants as fsConstants } from "node:fs";
+import { randomUUID } from "node:crypto";
 import { resolve, isAbsolute, join } from "node:path";
 import { logger } from "../log.js";
 import type { BotId, Config } from "../config/schema.js";
@@ -25,6 +27,127 @@ const EXT_ALLOWLIST: Record<string, string> = {
 function extensionFor(mime: string | undefined): string {
   if (!mime) return ".bin";
   return EXT_ALLOWLIST[mime] ?? ".bin";
+}
+
+// O_NOFOLLOW is unix-only; on Windows fs.constants.O_NOFOLLOW is undefined,
+// so we degrade to plain O_CREAT|O_EXCL|O_WRONLY there. The unix targets
+// (Linux/macOS, including Bun's container deployments) are where the
+// symlink-staging risk lives.
+const O_NOFOLLOW = fsConstants.O_NOFOLLOW ?? 0;
+const ATTACHMENT_OPEN_FLAGS =
+  fsConstants.O_CREAT | fsConstants.O_EXCL | fsConstants.O_WRONLY | O_NOFOLLOW;
+const MAX_FILENAME_RETRIES = 3;
+
+/**
+ * Materialize an attachment under `dir` with hardened semantics:
+ *
+ * - O_CREAT|O_EXCL: refuse to overwrite an existing file. On EEXIST we
+ *   regenerate the filename with a random UUID suffix and retry up to
+ *   MAX_FILENAME_RETRIES times before giving up.
+ * - O_NOFOLLOW: refuse to follow a symlink at the target path. If the
+ *   destination is a symlink (e.g. a less-trusted process staged one
+ *   pointing outside the dir), the open fails with ELOOP and we abort
+ *   with a distinct error code so ops can investigate.
+ *
+ * Throws with `code` set to one of:
+ *   ATTACHMENT_SYMLINK_REJECTED, ATTACHMENT_FILENAME_COLLISION,
+ *   ATTACHMENT_PATH_OUTSIDE_DIR.
+ *
+ * Returns the final path written.
+ */
+async function writeAttachmentExclusive(
+  dir: string,
+  baseName: string,
+  ext: string,
+  bytes: Uint8Array,
+): Promise<string> {
+  let filename = `${baseName}${ext}`;
+  for (let attempt = 0; ; attempt += 1) {
+    const target = join(dir, filename);
+    if (!isContainedIn(target, dir)) {
+      const err = new Error(
+        "attachment path outside data dir",
+      ) as NodeJS.ErrnoException;
+      err.code = "ATTACHMENT_PATH_OUTSIDE_DIR";
+      throw err;
+    }
+    let handle;
+    try {
+      handle = await open(target, ATTACHMENT_OPEN_FLAGS);
+    } catch (err) {
+      const code = (err as NodeJS.ErrnoException).code;
+      if (code === "EEXIST") {
+        // POSIX gives O_EXCL priority over O_NOFOLLOW, so a symlink
+        // staged at the target lands here on Linux/macOS rather than
+        // raising ELOOP. Distinguish with lstat so we can reject the
+        // symlink case loudly (security signal) while still allowing
+        // the regular-file collision case to retry under a fresh name.
+        let preexistingIsSymlink = false;
+        try {
+          const st = await lstat(target);
+          preexistingIsSymlink = st.isSymbolicLink();
+        } catch {
+          /* raced — treat as regular collision */
+        }
+        if (preexistingIsSymlink) {
+          const sym = new Error(
+            `attachment target is a symlink (refusing to follow): ${target}`,
+          ) as NodeJS.ErrnoException;
+          sym.code = "ATTACHMENT_SYMLINK_REJECTED";
+          throw sym;
+        }
+        if (attempt >= MAX_FILENAME_RETRIES) {
+          const collide = new Error(
+            `attachment filename collision after ${MAX_FILENAME_RETRIES} retries`,
+          ) as NodeJS.ErrnoException;
+          collide.code = "ATTACHMENT_FILENAME_COLLISION";
+          throw collide;
+        }
+        filename = `${baseName}-${randomUUID()}${ext}`;
+        continue;
+      }
+      if (code === "ELOOP") {
+        const sym = new Error(
+          `attachment target is a symlink (refusing to follow): ${target}`,
+        ) as NodeJS.ErrnoException;
+        sym.code = "ATTACHMENT_SYMLINK_REJECTED";
+        throw sym;
+      }
+      throw err;
+    }
+    try {
+      await handle.writeFile(bytes);
+    } finally {
+      await handle.close();
+    }
+    return target;
+  }
+}
+
+function handleAttachmentWriteError(
+  err: unknown,
+  errors: string[],
+  ctx: { botId: BotId; updateId: number; kind: "photo" | "document" },
+): boolean {
+  const code = (err as NodeJS.ErrnoException).code;
+  if (code === "ATTACHMENT_SYMLINK_REJECTED") {
+    log.error("attachment target is a symlink — refusing to write", {
+      bot_id: ctx.botId,
+      update_id: ctx.updateId,
+      kind: ctx.kind,
+    });
+    errors.push("symlink at attachment target");
+    return true;
+  }
+  if (code === "ATTACHMENT_FILENAME_COLLISION") {
+    errors.push("filename collision after retries");
+    return true;
+  }
+  if (code === "ATTACHMENT_PATH_OUTSIDE_DIR") {
+    errors.push("attachment path outside data dir");
+    return true;
+  }
+  return false;
 }
 
 export interface DownloadResult {
@@ -74,13 +197,26 @@ export async function downloadAttachments(
     }
     // Photos from Telegram are JPEG by convention; mime is not carried.
     const ext = ".jpg";
-    const filename = `${updateId}-${index}${ext}`;
-    const target = join(dir, filename);
-    if (!isContainedIn(target, dir)) {
-      errors.push("attachment path outside data dir");
-      return;
+    let target: string;
+    try {
+      target = await writeAttachmentExclusive(
+        dir,
+        `${updateId}-${index}`,
+        ext,
+        new Uint8Array(bytes),
+      );
+    } catch (err) {
+      if (
+        handleAttachmentWriteError(err, errors, {
+          botId,
+          updateId,
+          kind: "photo",
+        })
+      ) {
+        return;
+      }
+      throw err;
     }
-    await writeFile(target, new Uint8Array(bytes));
     attachments.push({
       kind: "photo",
       path: target,
@@ -116,13 +252,26 @@ export async function downloadAttachments(
       return;
     }
     const ext = extensionFor(doc.mime_type);
-    const filename = `${updateId}-${index}${ext}`;
-    const target = join(dir, filename);
-    if (!isContainedIn(target, dir)) {
-      errors.push("attachment path outside data dir");
-      return;
+    let target: string;
+    try {
+      target = await writeAttachmentExclusive(
+        dir,
+        `${updateId}-${index}`,
+        ext,
+        new Uint8Array(bytes),
+      );
+    } catch (err) {
+      if (
+        handleAttachmentWriteError(err, errors, {
+          botId,
+          updateId,
+          kind: "document",
+        })
+      ) {
+        return;
+      }
+      throw err;
     }
-    await writeFile(target, new Uint8Array(bytes));
     attachments.push({
       kind: "document",
       path: target,
@@ -150,7 +299,9 @@ export async function downloadAttachments(
 
 function isContainedIn(candidate: string, dir: string): boolean {
   const resolvedDir = isAbsolute(dir) ? dir : resolve(dir);
-  const resolvedCandidate = isAbsolute(candidate) ? candidate : resolve(candidate);
+  const resolvedCandidate = isAbsolute(candidate)
+    ? candidate
+    : resolve(candidate);
   return (
     resolvedCandidate === resolvedDir ||
     resolvedCandidate.startsWith(resolvedDir + "/") ||
@@ -162,7 +313,9 @@ function isContainedIn(candidate: string, dir: string): boolean {
  * Compute the total size (bytes) of files under `attachments/` across all bots.
  * Used by the disk-cap circuit breaker.
  */
-export async function computeAttachmentsDiskUsage(dataDir: string): Promise<number> {
+export async function computeAttachmentsDiskUsage(
+  dataDir: string,
+): Promise<number> {
   const root = resolve(dataDir, "attachments");
   try {
     return await sumDir(root);
@@ -231,7 +384,8 @@ export async function sweepExpiredAttachments(
     let paths: string[] = [];
     try {
       const parsed = JSON.parse(row.attachment_paths_json);
-      if (Array.isArray(parsed)) paths = parsed.filter((p) => typeof p === "string");
+      if (Array.isArray(parsed))
+        paths = parsed.filter((p) => typeof p === "string");
     } catch {
       /* malformed — still clear the column so it doesn't keep coming back */
     }

--- a/test/core/attachments.test.ts
+++ b/test/core/attachments.test.ts
@@ -7,7 +7,18 @@
 
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { Database } from "bun:sqlite";
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync, readFileSync, statSync, existsSync, readdirSync } from "node:fs";
+import {
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+  readFileSync,
+  statSync,
+  existsSync,
+  readdirSync,
+  symlinkSync,
+  lstatSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -81,23 +92,50 @@ afterEach(() => {
 
 describe("downloadAttachments", () => {
   test("photo: saves highest-res with jpg extension derived from mime (not file_path)", async () => {
-    const bytes = new Uint8Array([0xFF, 0xD8, 0xFF]); // JPEG magic
+    const bytes = new Uint8Array([0xff, 0xd8, 0xff]); // JPEG magic
     // Deliberately evil file_path on Telegram's side — attachments.ts should ignore it.
     const client = makeFakeClient([
-      { fileId: "fid-lo", filePath: "photos/evil.sh", bytes: new Uint8Array(10) },
-      { fileId: "fid-hi", filePath: "photos/../../etc/passwd", bytes, fileSize: bytes.length },
+      {
+        fileId: "fid-lo",
+        filePath: "photos/evil.sh",
+        bytes: new Uint8Array(10),
+      },
+      {
+        fileId: "fid-hi",
+        filePath: "photos/../../etc/passwd",
+        bytes,
+        fileSize: bytes.length,
+      },
     ]);
     const message: TelegramMessage = {
       message_id: 1,
       date: 1,
       chat: { id: 111, type: "private" },
       photo: [
-        { file_id: "fid-lo", file_unique_id: "u1", width: 10, height: 10, file_size: 10 },
-        { file_id: "fid-hi", file_unique_id: "u2", width: 100, height: 100, file_size: bytes.length },
+        {
+          file_id: "fid-lo",
+          file_unique_id: "u1",
+          width: 10,
+          height: 10,
+          file_size: 10,
+        },
+        {
+          file_id: "fid-hi",
+          file_unique_id: "u2",
+          width: 100,
+          height: 100,
+          file_size: bytes.length,
+        },
       ],
     };
 
-    const result = await downloadAttachments(config, "alpha", 42, message, client);
+    const result = await downloadAttachments(
+      config,
+      "alpha",
+      42,
+      message,
+      client,
+    );
     expect(result.errors).toHaveLength(0);
     expect(result.attachments).toHaveLength(1);
 
@@ -116,7 +154,12 @@ describe("downloadAttachments", () => {
   test("document: extension is derived from mime type, allowlist only", async () => {
     const bytes = new Uint8Array([1, 2, 3]);
     const client = makeFakeClient([
-      { fileId: "doc1", filePath: "docs/whatever.xyz", bytes, fileSize: bytes.length },
+      {
+        fileId: "doc1",
+        filePath: "docs/whatever.xyz",
+        bytes,
+        fileSize: bytes.length,
+      },
     ]);
     const message: TelegramMessage = {
       message_id: 1,
@@ -130,7 +173,13 @@ describe("downloadAttachments", () => {
         file_size: bytes.length,
       },
     };
-    const result = await downloadAttachments(config, "alpha", 99, message, client);
+    const result = await downloadAttachments(
+      config,
+      "alpha",
+      99,
+      message,
+      client,
+    );
     expect(result.errors).toHaveLength(0);
     expect(result.attachments).toHaveLength(1);
     const a = result.attachments[0];
@@ -154,23 +203,46 @@ describe("downloadAttachments", () => {
         file_size: bytes.length,
       },
     };
-    const result = await downloadAttachments(config, "alpha", 7, message, client);
+    const result = await downloadAttachments(
+      config,
+      "alpha",
+      7,
+      message,
+      client,
+    );
     expect(result.attachments[0].path).toMatch(/7-0\.bin$/);
   });
 
   test("photo: file_size > max_bytes is rejected pre-download", async () => {
     const client = makeFakeClient([
-      { fileId: "fid", filePath: "p", bytes: new Uint8Array(5000), fileSize: 5000 },
+      {
+        fileId: "fid",
+        filePath: "p",
+        bytes: new Uint8Array(5000),
+        fileSize: 5000,
+      },
     ]);
     const message: TelegramMessage = {
       message_id: 1,
       date: 1,
       chat: { id: 111, type: "private" },
       photo: [
-        { file_id: "fid", file_unique_id: "u", width: 100, height: 100, file_size: 5000 },
+        {
+          file_id: "fid",
+          file_unique_id: "u",
+          width: 100,
+          height: 100,
+          file_size: 5000,
+        },
       ],
     };
-    const result = await downloadAttachments(config, "alpha", 1, message, client);
+    const result = await downloadAttachments(
+      config,
+      "alpha",
+      1,
+      message,
+      client,
+    );
     expect(result.attachments).toHaveLength(0);
     expect(result.errors.some((e) => e.includes("too large"))).toBe(true);
   });
@@ -186,10 +258,22 @@ describe("downloadAttachments", () => {
       date: 1,
       chat: { id: 111, type: "private" },
       photo: [
-        { file_id: "fid", file_unique_id: "u", width: 100, height: 100, file_size: 10 },
+        {
+          file_id: "fid",
+          file_unique_id: "u",
+          width: 100,
+          height: 100,
+          file_size: 10,
+        },
       ],
     };
-    const result = await downloadAttachments(config, "alpha", 1, message, client);
+    const result = await downloadAttachments(
+      config,
+      "alpha",
+      1,
+      message,
+      client,
+    );
     expect(result.attachments).toHaveLength(0);
     expect(result.errors.some((e) => e.includes("exceeded"))).toBe(true);
   });
@@ -208,9 +292,17 @@ describe("downloadAttachments", () => {
         file_size: 10,
       },
     };
-    const result = await downloadAttachments(config, "alpha", 1, message, client);
+    const result = await downloadAttachments(
+      config,
+      "alpha",
+      1,
+      message,
+      client,
+    );
     expect(result.attachments).toHaveLength(0);
-    expect(result.errors.some((e) => e.includes("getFile") || e.includes("resolve"))).toBe(true);
+    expect(
+      result.errors.some((e) => e.includes("getFile") || e.includes("resolve")),
+    ).toBe(true);
   });
 
   test("downloadFile returns null → error recorded", async () => {
@@ -234,7 +326,13 @@ describe("downloadAttachments", () => {
         file_size: 10,
       },
     };
-    const result = await downloadAttachments(config, "alpha", 1, message, client);
+    const result = await downloadAttachments(
+      config,
+      "alpha",
+      1,
+      message,
+      client,
+    );
     expect(result.attachments).toHaveLength(0);
     expect(result.errors.some((e) => e.includes("download"))).toBe(true);
   });
@@ -247,10 +345,113 @@ describe("downloadAttachments", () => {
       chat: { id: 111, type: "private" },
       text: "just text",
     };
-    const result = await downloadAttachments(config, "alpha", 1, message, client);
+    const result = await downloadAttachments(
+      config,
+      "alpha",
+      1,
+      message,
+      client,
+    );
     expect(result.attachments).toHaveLength(0);
     expect(result.errors).toHaveLength(0);
   });
+
+  // O_EXCL: pre-existing file at the destination path must NOT be
+  // overwritten. We retry with a UUID-suffixed filename instead.
+  test("EEXIST collision: regenerates filename with UUID and retries", async () => {
+    const dir = join(tmpDir, "attachments", "alpha");
+    mkdirSync(dir, { recursive: true });
+    const collidePath = join(dir, "55-0.jpg");
+    writeFileSync(collidePath, "preexisting");
+
+    const bytes = new Uint8Array([0xff, 0xd8, 0xff]); // JPEG magic
+    const client = makeFakeClient([
+      { fileId: "fid", filePath: "p", bytes, fileSize: bytes.length },
+    ]);
+    const message: TelegramMessage = {
+      message_id: 1,
+      date: 1,
+      chat: { id: 111, type: "private" },
+      photo: [
+        {
+          file_id: "fid",
+          file_unique_id: "u",
+          width: 100,
+          height: 100,
+          file_size: bytes.length,
+        },
+      ],
+    };
+    const result = await downloadAttachments(
+      config,
+      "alpha",
+      55,
+      message,
+      client,
+    );
+
+    expect(result.errors).toHaveLength(0);
+    expect(result.attachments).toHaveLength(1);
+    // Pre-existing file is untouched (no overwrite).
+    expect(readFileSync(collidePath, "utf8")).toBe("preexisting");
+    // Written path differs from the colliding one and carries a UUID suffix.
+    const written = result.attachments[0].path;
+    expect(written).not.toBe(collidePath);
+    expect(written).toMatch(
+      /55-0-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\.jpg$/,
+    );
+    // Bytes were actually written.
+    expect(readFileSync(written)).toEqual(Buffer.from(bytes));
+  });
+
+  // O_NOFOLLOW: a symlink staged at the destination path must be rejected
+  // outright — we do not follow it (which would let an attacker who can
+  // write into the attachments dir redirect our writes outside it).
+  test.if(process.platform !== "win32")(
+    "symlink at target: refuses to follow (O_NOFOLLOW)",
+    async () => {
+      const dir = join(tmpDir, "attachments", "alpha");
+      mkdirSync(dir, { recursive: true });
+      const decoy = join(tmpDir, "outside-decoy.txt");
+      writeFileSync(decoy, "should-not-be-overwritten");
+      const symlinkPath = join(dir, "77-0.jpg");
+      symlinkSync(decoy, symlinkPath);
+
+      const bytes = new Uint8Array([0xff, 0xd8, 0xff]);
+      const client = makeFakeClient([
+        { fileId: "fid", filePath: "p", bytes, fileSize: bytes.length },
+      ]);
+      const message: TelegramMessage = {
+        message_id: 1,
+        date: 1,
+        chat: { id: 111, type: "private" },
+        photo: [
+          {
+            file_id: "fid",
+            file_unique_id: "u",
+            width: 100,
+            height: 100,
+            file_size: bytes.length,
+          },
+        ],
+      };
+      const result = await downloadAttachments(
+        config,
+        "alpha",
+        77,
+        message,
+        client,
+      );
+
+      // No attachment recorded; a symlink-specific error is reported.
+      expect(result.attachments).toHaveLength(0);
+      expect(result.errors.some((e) => e.includes("symlink"))).toBe(true);
+      // Decoy target is untouched — the write didn't follow the symlink.
+      expect(readFileSync(decoy, "utf8")).toBe("should-not-be-overwritten");
+      // The symlink itself is left in place for ops to inspect.
+      expect(lstatSync(symlinkPath).isSymbolicLink()).toBe(true);
+    },
+  );
 });
 
 describe("computeAttachmentsDiskUsage", () => {
@@ -381,13 +582,13 @@ describe("sweepExpiredAttachments", () => {
     expect(existsSync(attKeep)).toBe(true);
 
     // attachment_paths_json is cleared only for the old turn.
-    const oldRow = db.query("SELECT attachment_paths_json FROM turns WHERE id=?").get(oldTurn) as
-      | { attachment_paths_json: string | null }
-      | null;
+    const oldRow = db
+      .query("SELECT attachment_paths_json FROM turns WHERE id=?")
+      .get(oldTurn) as { attachment_paths_json: string | null } | null;
     expect(oldRow?.attachment_paths_json).toBeNull();
-    const recentRow = db.query("SELECT attachment_paths_json FROM turns WHERE id=?").get(recentTurn) as
-      | { attachment_paths_json: string | null }
-      | null;
+    const recentRow = db
+      .query("SELECT attachment_paths_json FROM turns WHERE id=?")
+      .get(recentTurn) as { attachment_paths_json: string | null } | null;
     expect(recentRow?.attachment_paths_json).not.toBeNull();
   });
 
@@ -434,9 +635,9 @@ describe("sweepExpiredAttachments", () => {
     const result = await sweepExpiredAttachments(db, tmpDir, 100);
     expect(result.turns).toBe(1);
     expect(result.files).toBe(0);
-    const row = db.query("SELECT attachment_paths_json FROM turns WHERE id=?").get(turnId) as
-      | { attachment_paths_json: string | null }
-      | null;
+    const row = db
+      .query("SELECT attachment_paths_json FROM turns WHERE id=?")
+      .get(turnId) as { attachment_paths_json: string | null } | null;
     expect(row?.attachment_paths_json).toBeNull();
   });
 
@@ -496,7 +697,15 @@ describe("downloadAttachments - max_per_turn enforcement", () => {
       message_id: 1,
       date: 1,
       chat: { id: 111, type: "private" },
-      photo: [{ file_id: "p1", file_unique_id: "u", width: 1, height: 1, file_size: bytes.length }],
+      photo: [
+        {
+          file_id: "p1",
+          file_unique_id: "u",
+          width: 1,
+          height: 1,
+          file_size: bytes.length,
+        },
+      ],
       document: {
         file_id: "d1",
         file_unique_id: "u",
@@ -504,7 +713,13 @@ describe("downloadAttachments - max_per_turn enforcement", () => {
         file_size: bytes.length,
       },
     };
-    const result = await downloadAttachments(config, "alpha", 1, message, client);
+    const result = await downloadAttachments(
+      config,
+      "alpha",
+      1,
+      message,
+      client,
+    );
     expect(result.attachments).toHaveLength(1); // photo accepted
     expect(result.errors.some((e) => e.includes("too many"))).toBe(true);
   });


### PR DESCRIPTION
## Summary

P2 from the rc.7 security review (deferred to rc.8). The attachment download path materialized files via `writeFile(target, bytes)`, which has two security-relevant behaviors:

1. **Silently overwrites pre-existing files.** Filenames are derived from `update_id` + index, so collisions are rare but possible (replays after restart, long-running deployments, anything an attacker stages ahead of time). An overwrite would clobber the staged content and race any concurrent reader.
2. **Follows symlinks at the destination.** A symlink staged in the attachments dir by a less-trusted process would redirect our writes outside the intended directory.

This PR replaces `writeFile()` with `fs.open(target, O_CREAT | O_EXCL | O_WRONLY | O_NOFOLLOW)` and handles the two error modes:

- **EEXIST:** retry under `<update_id>-<index>-<uuid>.<ext>` (up to 3 retries). The pre-existing file is left untouched. lstat-distinguishes regular-file collisions (legitimate retry) from symlinks (security signal — POSIX gives O_EXCL priority over O_NOFOLLOW when both are set on Linux/macOS, so symlinks otherwise land here silently).
- **ELOOP:** kept as a portable fallback for any platform/runtime where O_NOFOLLOW takes priority. Same `ATTACHMENT_SYMLINK_REJECTED` outcome.

Symlink rejections are logged at `error` level with `bot_id` / `update_id` so ops can investigate. The decoy file the symlink pointed at is never written through.

The bytes are written via `handle.writeFile(bytes)` and the handle is closed in a `finally` block — preserving the convenience that `writeFile()` was providing.

## Test plan

- [x] `bun run typecheck`
- [x] `bun run format` (only `src/core/attachments.ts` + `test/core/attachments.test.ts` + `CHANGELOG.md` are touched in this PR; the test file gets a one-time prettier reformat alongside the new tests)
- [x] `bun test` — 1144 pass / 0 fail (no regressions)
- [x] New test: pre-existing regular file at target → EEXIST → UUID-suffixed retry succeeds, original untouched
- [x] New test: symlink staged at target → rejected with symlink-specific error, decoy unmodified, symlink left in place for ops (skipped on Windows)

## Notes for reviewers

- Branched from `main`, **not** from `rc.7/security-hardening`, so this can land independently for rc.8.
- CHANGELOG entry is under `## [Unreleased]`.
- One-time prettier reformat of `test/core/attachments.test.ts` is bundled in (the file wasn't prettier-clean on main; it had to be normalized to add tests cleanly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)