### PR TITLE
security(rc.8): runner.secrets map for inlined-secret redaction (P2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 
 ## [Unreleased]
 
+### Added
+
+- **`runner.secrets`** — opt-in sibling of `runner.env` for inlined sensitive
+  values. Same shape (string→string), merged on top of `runner.env` into the
+  spawn environment, but every value is registered with the log redactor at
+  config load and rendered as `<redacted:N chars>` in `torana validate`
+  output. Continue to prefer `${VAR}` indirection in `env`; reach for
+  `secrets` only when env-var indirection isn't feasible (committed config,
+  CI). Setting the same key in both `env` and `secrets` is rejected at load
+  time. Closes the rc.7 P2 deferred item where `runner.env` values
+  (`ANTHROPIC_API_KEY`, DB credentials) leaked through `torana validate` and
+  any log line that echoed resolved config.
+
 ## [1.0.0-rc.6] - 2026-04-21
 
 ### Changed

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -24,6 +24,8 @@ A missing `${VAR}` (no default) is a fatal load error. Numeric fields use `z.coe
 
 To inherit a specific var, reference it via `${VAR}`. To disable PATH inheritance, set `PATH: ""` explicitly. Rationale: explicit > implicit, and avoids the classic "works locally, breaks in prod because PATH differs" footgun.
 
+`runner.secrets` is a sibling of `runner.env` for **inlined sensitive values**. Same shape (string→string), merged on top of `runner.env` into the spawn env, but every value is registered with the log redactor at load time and printed as `<redacted:N chars>` in `torana validate`. Setting the same key in both `env` and `secrets` is rejected at load time. Prefer `${VAR}` indirection in `env`; use `secrets` only when env-var indirection isn't feasible. See [Inlined secrets](runners.md#inlined-secrets-runnersecrets) in the runners doc.
+
 ## Config resolution order
 
 1. `--config <path>` CLI flag

--- a/docs/runners.md
+++ b/docs/runners.md
@@ -159,6 +159,25 @@ If your wrapper subprocess emits Codex-style state-change events (`thread.starte
 
 Long-lived `codex-jsonl` wrappers can emit a synthetic `{"type":"ready"}` line on startup so torana promotes the runner to ready before the first turn.
 
+## Inlined secrets: `runner.secrets`
+
+`runner.env` values are **not** auto-redacted — they land in `torana validate` output and any log line that echoes resolved config in cleartext. Two ways to keep secrets out of those:
+
+1. **Preferred:** keep secrets out of YAML entirely with `${VAR}` indirection. The literal value lives only in your secret store / process env.
+
+2. **Fallback:** when env-var indirection isn't feasible (committed config, CI), use the sibling `runner.secrets` map. Same shape as `runner.env` (string→string, merged into the spawn env on top of `env`), but every value is registered with the log redactor at config load and printed as `<redacted:N chars>` in `torana validate`.
+
+```yaml
+runner:
+  type: claude-code
+  env:
+    CLAUDE_CONFIG_DIR: /data/state/claude-config/cato   # not sensitive
+  secrets:
+    ANTHROPIC_API_KEY: sk-ant-XXXXXXXXXXXXXXXXXXXXX     # masked in logs + validate
+```
+
+Setting the same key in both `env` and `secrets` is rejected at load time — pick one. Values shorter than 6 characters are not added to the redactor (they would cause pathological substring matches in unrelated log text); use `${VAR}` indirection in `env` for short tokens that absolutely must be redacted.
+
 ## Hybrid configurations
 
 Different bots in the same gateway can use different runners. The dispatcher routes each Telegram update to its bot's runner independently. Example: one Claude Code bot for code review and one Codex bot for prose drafting:

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -493,15 +493,22 @@ function stubClient(): AgentApiClient {
   });
 }
 
-function redactForPrint(config: unknown): unknown {
-  if (config === null || typeof config !== "object") return config;
-  if (Array.isArray(config)) return config.map(redactForPrint);
+function redactForPrint(config: unknown, parentKey?: string): unknown {
+  if (config === null || config === undefined) return config;
+  if (typeof config !== "object") return config;
+  if (Array.isArray(config)) return config.map((v) => redactForPrint(v, parentKey));
   const out: Record<string, unknown> = {};
   for (const [k, v] of Object.entries(config as Record<string, unknown>)) {
+    // bots[].runner.secrets is a flat Record<string,string> whose every value
+    // is — by definition — sensitive. Redact each leaf, not the map.
+    if (parentKey === "secrets") {
+      out[k] = typeof v === "string" && v.length > 0 ? `<redacted:${v.length} chars>` : v;
+      continue;
+    }
     if (k === "token" || k === "secret") {
       out[k] = typeof v === "string" && v.length > 0 ? `<redacted:${v.length} chars>` : v;
     } else {
-      out[k] = redactForPrint(v);
+      out[k] = redactForPrint(v, k);
     }
   }
   return out;

--- a/src/config/load.ts
+++ b/src/config/load.ts
@@ -332,6 +332,12 @@ function collectSecrets(
   if (config.transport.webhook?.secret) secrets.add(config.transport.webhook.secret);
   for (const bot of config.bots) {
     if (bot.token) secrets.add(bot.token);
+    // runner.secrets values are register-as-secret by definition. The
+    // min-length filter below still applies — sub-6-char values aren't useful
+    // redaction targets (pathological substring matches in unrelated text).
+    for (const value of Object.values(bot.runner.secrets ?? {})) {
+      if (value) secrets.add(value);
+    }
   }
   for (const tok of agentApiTokens) {
     if (tok.secret) secrets.add(tok.secret);

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -213,6 +213,14 @@ export const ClaudeCodeRunnerSchema = z
     args: z.array(z.string()).default([]),
     cwd: PathString.optional(),
     env: z.record(z.string(), z.string()).default({}),
+    /**
+     * Sibling of `env` whose values are registered with the log redactor at
+     * config load and rendered as `<redacted>` in `torana validate` output.
+     * Merged into the spawn env on top of `env` (collisions rejected at load).
+     * Prefer `${VAR}` indirection in `env` when feasible — `secrets:` is the
+     * fallback for inlined values. Optional: omit the key for non-secret runners.
+     */
+    secrets: z.record(z.string(), z.string()).optional(),
     pass_continue_flag: BoolPermissive.default(true),
   })
   .strict();
@@ -235,6 +243,8 @@ export const CodexRunnerSchema = z
     args: z.array(z.string()).default([]),
     cwd: PathString.optional(),
     env: z.record(z.string(), z.string()).default({}),
+    /** See `ClaudeCodeRunnerSchema.secrets`. */
+    secrets: z.record(z.string(), z.string()).optional(),
     /** Capture the first turn's thread_id and resume on subsequent turns. */
     pass_resume_flag: BoolPermissive.default(true),
     /**
@@ -263,6 +273,8 @@ export const CommandRunnerSchema = z
     protocol: z.enum(["jsonl-text", "claude-ndjson", "codex-jsonl"]),
     cwd: PathString.optional(),
     env: z.record(z.string(), z.string()).default({}),
+    /** See `ClaudeCodeRunnerSchema.secrets`. */
+    secrets: z.record(z.string(), z.string()).optional(),
     on_reset: z.enum(["signal", "restart"]).default("signal"),
   })
   .strict();
@@ -449,6 +461,22 @@ export const ConfigSchema = z
       }
     }
 
+    // runner.env vs runner.secrets: same key in both is ambiguous and almost
+    // always a config bug. Reject explicitly so the operator picks one.
+    for (const [idx, bot] of cfg.bots.entries()) {
+      const envKeys = Object.keys(bot.runner.env);
+      const secretKeys = new Set(Object.keys(bot.runner.secrets ?? {}));
+      for (const k of envKeys) {
+        if (secretKeys.has(k)) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            path: ["bots", idx, "runner", "secrets", k],
+            message: `key '${k}' is set in both runner.env and runner.secrets — pick one`,
+          });
+        }
+      }
+    }
+
     // codex approval_mode='yolo' requires explicit acknowledge_dangerous=true.
     for (const [idx, bot] of cfg.bots.entries()) {
       if (
@@ -542,6 +570,7 @@ export type CommandRunnerConfig = z.infer<typeof CommandRunnerSchema>;
 export const SECRET_PATHS = [
   "transport.webhook.secret",
   "bots[].token",
+  "bots[].runner.secrets[*]",
   "agent_api.tokens[].secret_ref",
 ] as const;
 

--- a/src/runner/claude-code.ts
+++ b/src/runner/claude-code.ts
@@ -586,7 +586,12 @@ export class ClaudeCodeRunner implements AgentRunner {
 
   private buildEnv(): Record<string, string> {
     // runner.env is the complete env except PATH, which inherits by default.
-    const env: Record<string, string> = { ...this.config.env };
+    // runner.secrets merges on top — same shape, registered with the log
+    // redactor at load time. Schema rejects key collisions between the two.
+    const env: Record<string, string> = {
+      ...this.config.env,
+      ...(this.config.secrets ?? {}),
+    };
     if (!("PATH" in env)) {
       env.PATH = process.env.PATH ?? "";
     } else if (env.PATH === "") {

--- a/src/runner/codex.ts
+++ b/src/runner/codex.ts
@@ -788,7 +788,12 @@ export class CodexRunner implements AgentRunner {
 
   private buildEnv(): Record<string, string> {
     // runner.env is the complete env except PATH, which inherits by default.
-    const env: Record<string, string> = { ...this.config.env };
+    // runner.secrets merges on top — same shape, registered with the log
+    // redactor at load time. Schema rejects key collisions between the two.
+    const env: Record<string, string> = {
+      ...this.config.env,
+      ...(this.config.secrets ?? {}),
+    };
     if (!("PATH" in env)) {
       env.PATH = process.env.PATH ?? "";
     } else if (env.PATH === "") {

--- a/src/runner/command.ts
+++ b/src/runner/command.ts
@@ -607,7 +607,12 @@ export class CommandRunner implements AgentRunner {
   }
 
   private buildEnv(): Record<string, string> {
-    const env: Record<string, string> = { ...this.config.env };
+    // runner.secrets merges on top of runner.env — same shape, but registered
+    // with the log redactor at load time. Schema rejects key collisions.
+    const env: Record<string, string> = {
+      ...this.config.env,
+      ...(this.config.secrets ?? {}),
+    };
     if (!("PATH" in env)) {
       env.PATH = process.env.PATH ?? "";
     } else if (env.PATH === "") {

--- a/test/cli/cli.test.ts
+++ b/test/cli/cli.test.ts
@@ -179,6 +179,31 @@ describe("CLI validate", () => {
     expect(exitCode).not.toBe(0);
     expect(stderr).toMatch(/config/);
   }, 15_000);
+
+  test("redacts runner.secrets values in validate output", async () => {
+    // Inline secrets in runner.secrets must NEVER appear in the validate
+    // output — neither the JSON config dump nor any log line. Closes the
+    // rc.7 P2 finding where ANTHROPIC_API_KEY etc. leaked from runner.env.
+    const FAKE_API_KEY = "sk-ant-fake-but-distinctive-redaction-target";
+    const FAKE_DB_PW = "hunter2-also-distinctive";
+    const cfgBody = `${MINIMAL_CONFIG(tmpDir)}
+      secrets:
+        ANTHROPIC_API_KEY: ${FAKE_API_KEY}
+        DB_PASSWORD: ${FAKE_DB_PW}
+`;
+    const cfg = writeConfig("torana.yaml", cfgBody);
+    const { stdout, stderr, exitCode } = await runCli(["validate", "--config", cfg]);
+    expect(exitCode).toBe(0);
+    expect(stdout).not.toContain(FAKE_API_KEY);
+    expect(stdout).not.toContain(FAKE_DB_PW);
+    expect(stderr).not.toContain(FAKE_API_KEY);
+    expect(stderr).not.toContain(FAKE_DB_PW);
+    // Map structure preserved with the redacted-N-chars marker so operators
+    // can still verify the keys they configured.
+    expect(stdout).toContain("ANTHROPIC_API_KEY");
+    expect(stdout).toContain(`<redacted:${FAKE_API_KEY.length} chars>`);
+    expect(stdout).toContain(`<redacted:${FAKE_DB_PW.length} chars>`);
+  }, 15_000);
 });
 
 describe("CLI migrate --dry-run", () => {

--- a/test/config/load.test.ts
+++ b/test/config/load.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { loadConfigFromString, interpolate, ConfigLoadError } from "../../src/config/load.js";
+import { logger, resetLoggerState, setLogFormat, setLogLevel, setSecrets } from "../../src/log.js";
 
 const MINIMAL = `
 version: 1
@@ -221,6 +222,87 @@ bots:
     if (config.bots[1].runner.type === "codex") {
       expect(config.bots[1].runner.model).toBe("gpt-5");
     }
+  });
+
+  test("runner.secrets values are collected for the redactor", () => {
+    const raw = MINIMAL.replace(
+      "    runner:\n      type: claude-code\n      cli_path: claude",
+      [
+        "    runner:",
+        "      type: claude-code",
+        "      cli_path: claude",
+        "      env:",
+        "        FOO: bar",
+        "      secrets:",
+        "        ANTHROPIC_API_KEY: sk-ant-this-is-a-fake-secret-value",
+        "        DB_PASSWORD: hunter2-also-a-secret",
+      ].join("\n"),
+    );
+    const loaded = loadConfigFromString(raw);
+    expect(loaded.secrets).toContain("sk-ant-this-is-a-fake-secret-value");
+    expect(loaded.secrets).toContain("hunter2-also-a-secret");
+    // env values should NOT be in the redaction set.
+    expect(loaded.secrets).not.toContain("bar");
+    const r = loaded.config.bots[0].runner;
+    expect(r.type).toBe("claude-code");
+    if (r.type === "claude-code") {
+      expect(r.env).toEqual({ FOO: "bar" });
+      expect(r.secrets).toEqual({
+        ANTHROPIC_API_KEY: "sk-ant-this-is-a-fake-secret-value",
+        DB_PASSWORD: "hunter2-also-a-secret",
+      });
+    }
+  });
+
+  test("runner.secrets values are masked by the log redactor end-to-end", () => {
+    // Simulate the cli.ts path: load → setSecrets → log → expect redaction.
+    const raw = MINIMAL.replace(
+      "    runner:\n      type: claude-code\n      cli_path: claude",
+      [
+        "    runner:",
+        "      type: claude-code",
+        "      cli_path: claude",
+        "      secrets:",
+        "        ANTHROPIC_API_KEY: sk-ant-this-is-a-fake-secret-value",
+      ].join("\n"),
+    );
+    const loaded = loadConfigFromString(raw);
+
+    const captured: string[] = [];
+    const orig = console.log;
+    console.log = (m: unknown) => captured.push(String(m));
+    try {
+      setLogFormat("json");
+      setLogLevel("info");
+      setSecrets(loaded.secrets);
+      // Mimic something like a runner startup banner that echoes the resolved
+      // env back into the log stream.
+      logger("test").info("runner env resolved", {
+        env: { ANTHROPIC_API_KEY: "sk-ant-this-is-a-fake-secret-value" },
+      });
+    } finally {
+      console.log = orig;
+      resetLoggerState();
+    }
+    expect(captured).toHaveLength(1);
+    const parsed = JSON.parse(captured[0]!);
+    expect(parsed.env.ANTHROPIC_API_KEY).toBe("<redacted>");
+  });
+
+  test("rejects key collision between runner.env and runner.secrets", () => {
+    const raw = MINIMAL.replace(
+      "    runner:\n      type: claude-code\n      cli_path: claude",
+      [
+        "    runner:",
+        "      type: claude-code",
+        "      cli_path: claude",
+        "      env:",
+        "        SHARED_KEY: from-env",
+        "      secrets:",
+        "        SHARED_KEY: from-secrets",
+      ].join("\n"),
+    );
+    expect(() => loadConfigFromString(raw)).toThrow(/runner\.env and runner\.secrets/);
   });
 
   test("command runner accepts new codex-jsonl protocol", () => {


### PR DESCRIPTION
## Summary

- Adds an opt-in `runner.secrets` sibling of `runner.env` whose values get registered with the log redactor at config load. Closes the rc.7 P2 deferred item where inlined `runner.env` values (ANTHROPIC_API_KEY, DB credentials, third-party tokens) leaked through `torana validate` output and any log line that echoed resolved config.
- Schema rejects key collisions between `env` and `secrets`. Values < 6 chars don't make it into the redactor (pathological substring matches); use `${VAR}` indirection for those.
- `torana validate` now redacts every value inside `bots[].runner.secrets` as `<redacted:N chars>`, matching the existing `token`/`secret` key behavior.

`${VAR}` indirection in `env` remains the preferred pattern; `secrets:` is documented as the fallback for cases where indirection isn't feasible (committed config, CI). Field is optional — existing configs need no changes.

## Branch

Branched from `main` (not `rc.7/security-hardening`) so this lands independently for rc.8.

## Test plan

- [x] `bun run typecheck` passes
- [x] `bun test` — full suite (1146 pass, 13 skip, 0 fail across 113 files)
- [x] New tests cover three paths: load-side (values land in `LoadedConfig.secrets`), log-side (`setSecrets` + emit → `<redacted>`), validate-side (subprocess CLI run → masked stdout)
- [x] env↔secrets key-collision is rejected at load time
- [ ] Manual smoke: `torana validate` against a config with `runner.secrets` shows `<redacted:N chars>` per key

🤖 Generated with [Claude Code](https://claude.com/claude-code)