### PR TITLE
security(rc.8): hide runner_type from /v1/bots by default (P2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 
 ## [Unreleased]
 
+### Changed
+
+- **Agent API: `GET /v1/bots` no longer returns `runner_type` by default.**
+  The field — `claude-code`, `codex`, or `command` — leaks deployment
+  shape to any holder of a bearer token, telling an attacker which
+  side-channels (prompt injection, tool-use abuse, command-shell access)
+  are worth probing. The default response now includes only `bot_id` and
+  `supports_side_sessions`. Operators who need the field (e.g. callers
+  that branch on runner kind) opt in by setting
+  `agent_api.expose_runner_type: true`.
+
+  Soft break for the `torana bots list` CLI: when the field is hidden,
+  the `RUNNER` column is dropped from the table rather than displayed
+  empty. The typed client's `BotsListItem.runner_type` is now optional
+  (`string | undefined`).
+
 ## [1.0.0-rc.6] - 2026-04-21
 
 ### Changed
@@ -88,11 +104,11 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
   `TORANA_TOKEN` env, and named profiles (see below). Stable exit codes
   (0/1/2/3/4/5/6/7) for scripting. See [docs/cli.md](docs/cli.md).
 - **CLI profile store.** `torana config init | add-profile | list-profiles |
-  remove-profile | show` manages a TOML file at
+remove-profile | show` manages a TOML file at
   `$XDG_CONFIG_HOME/torana/config.toml` (mode 0600). Every agent-api
   subcommand resolves credentials with the precedence
   `flag > env > --profile NAME > default profile`. `torana doctor
-  --profile NAME` runs the R001..R003 remote probes against the resolved
+--profile NAME` runs the R001..R003 remote probes against the resolved
   server.
 - **`--file @-` on `torana ask` / `torana inject`.** Reads attachment bytes
   from stdin with magic-byte MIME detection (PNG, JPEG, GIF, WebP, PDF;
@@ -100,7 +116,7 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
   a second `@-` on the same call is a usage error.
 - **Skills + Codex plugin.** `skills/torana-ask/SKILL.md` and
   `skills/torana-inject/SKILL.md` ship with the package. `torana skills
-  install --host=claude|codex` copies them into
+install --host=claude|codex` copies them into
   `$CLAUDE_CONFIG_DIR/skills` / `$XDG_DATA_HOME/agents/skills` (default
   refuses on divergence; `--force` overwrites). `codex-plugin/` contains
   a manifest + marketplace.json entry for one-line Codex install; a

--- a/docs/agent-api.md
+++ b/docs/agent-api.md
@@ -38,6 +38,7 @@ agent_api:
     max_timeout_ms: 300_000
     max_body_bytes: 104_857_600     # 100 MiB
     max_files_per_request: 10
+  expose_runner_type: false         # opt-in: include `runner_type` in /v1/bots
 ```
 
 All fields have defaults. Minimally you need `enabled: true` and at least one
@@ -239,14 +240,27 @@ Read the state of any turn the caller's token owns.
 ```json
 {
   "bots": [
-    {"bot_id": "reviewer", "runner_type": "claude-code", "supports_side_sessions": true},
-    {"bot_id": "drafter",  "runner_type": "codex",       "supports_side_sessions": true}
+    {"bot_id": "reviewer", "supports_side_sessions": true},
+    {"bot_id": "drafter",  "supports_side_sessions": true}
   ]
 }
 ```
 
 Filtered to bots the caller's token is scoped to. Useful for discovery: a
 CI script can run `torana bots list` to see what it's allowed to drive.
+
+`runner_type` is **omitted by default** so a bearer token doesn't leak
+deployment shape (see [Security model](#security-model)). Set
+`agent_api.expose_runner_type: true` in the gateway config to include it:
+
+```json
+{
+  "bots": [
+    {"bot_id": "reviewer", "runner_type": "claude-code", "supports_side_sessions": true},
+    {"bot_id": "drafter",  "runner_type": "codex",       "supports_side_sessions": true}
+  ]
+}
+```
 
 ### `GET /v1/bots/:bot_id/sessions` · `DELETE /v1/bots/:bot_id/sessions/:session_id`
 
@@ -344,6 +358,11 @@ Bucket sequence for both histograms (ms): `50, 100, 250, 500, 1000, 2500, 5000, 
   `parseMultipartRequest`.
 - **Idempotency is a safety feature**, not just a convenience: retrying an
   `send` won't double-send even if the caller's network flapped.
+- **`runner_type` is hidden by default.** `GET /v1/bots` omits each bot's
+  runner kind (`claude-code` / `codex` / `command`) unless the operator
+  sets `agent_api.expose_runner_type: true`. This keeps a leaked token
+  from revealing what side-channels (prompt injection, tool-use abuse,
+  command-shell access) are worth probing.
 
 ### Session-id sharing across tokens
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -227,8 +227,10 @@ List bots the token is authorized for.
 torana bots list [options]
 ```
 
-Prints a table (or JSON with `--json`) of `bot_id`, `runner_type`,
-`supports_side_sessions`.
+Prints a table (or JSON with `--json`) of `bot_id` and
+`supports_side_sessions`. The `RUNNER` column is shown only when the
+gateway has `agent_api.expose_runner_type: true` (off by default — see
+the Agent API security model).
 
 ### `torana config`
 

--- a/src/agent-api/client.ts
+++ b/src/agent-api/client.ts
@@ -50,8 +50,10 @@ export class AgentApiError extends Error {
 
 export interface BotsListItem {
   bot_id: string;
-  runner_type: string;
   supports_side_sessions: boolean;
+  // Present iff the gateway has `agent_api.expose_runner_type: true`.
+  // Off by default — see docs/agent-api.md "Security model".
+  runner_type?: string;
 }
 
 export interface BotsListResponse {

--- a/src/agent-api/router.ts
+++ b/src/agent-api/router.ts
@@ -79,16 +79,22 @@ export function registerAgentApiRoutes(
       const a = authenticate(deps.tokens, req.headers.get("Authorization"));
       if ("kind" in a) return mapAuthFailure(a);
       const permitted = new Set(a.token.bot_ids);
+      const exposeRunner = deps.config.agent_api?.expose_runner_type === true;
       const bots = deps.registry.botIds
         .filter((id) => permitted.has(id))
         .sort()
         .map((id) => {
           const bot = deps.registry.bot(id)!;
-          return {
+          const item: {
+            bot_id: string;
+            supports_side_sessions: boolean;
+            runner_type?: string;
+          } = {
             bot_id: id,
-            runner_type: bot.botConfig.runner.type,
             supports_side_sessions: bot.runner.supportsSideSessions(),
           };
+          if (exposeRunner) item.runner_type = bot.botConfig.runner.type;
+          return item;
         });
       return jsonResponse(200, { bots });
     }),

--- a/src/cli/bots.ts
+++ b/src/cli/bots.ts
@@ -86,11 +86,18 @@ export async function runBots(
     );
   }
 
-  const rows = response.bots.map((b) => [
-    b.bot_id,
-    b.runner_type,
-    b.supports_side_sessions ? "yes" : "no",
-  ]);
-  const lines = formatTable(["BOT_ID", "RUNNER", "ASK?"], rows);
+  // Drop the RUNNER column entirely when no row carries `runner_type`
+  // (the gateway has `expose_runner_type: false`, the default). Keeps
+  // the table from showing a useless empty column.
+  const showRunner = response.bots.some((b) => b.runner_type !== undefined);
+  const rows = response.bots.map((b) =>
+    showRunner
+      ? [b.bot_id, b.runner_type ?? "—", b.supports_side_sessions ? "yes" : "no"]
+      : [b.bot_id, b.supports_side_sessions ? "yes" : "no"],
+  );
+  const headers = showRunner
+    ? ["BOT_ID", "RUNNER", "ASK?"]
+    : ["BOT_ID", "ASK?"];
+  const lines = formatTable(headers, rows);
   return renderText(lines, ExitCode.success);
 }

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -345,6 +345,11 @@ export const AgentApiSchema = z
     side_sessions: AgentApiSideSessionsSchema,
     send: AgentApiSendSchema,
     ask: AgentApiAskSchema,
+    // When true, GET /v1/bots includes each bot's `runner_type`
+    // (claude-code/codex/command). Off by default so a bearer token
+    // doesn't reveal deployment shape — flip on if a caller actually
+    // needs to branch on runner type.
+    expose_runner_type: BoolPermissive.default(false),
   })
   .strict()
   .default({
@@ -363,6 +368,7 @@ export const AgentApiSchema = z
       max_body_bytes: 100 * 1024 * 1024,
       max_files_per_request: 10,
     },
+    expose_runner_type: false,
   });
 
 // ---------- root ----------

--- a/test/agent-api/router.test.ts
+++ b/test/agent-api/router.test.ts
@@ -47,7 +47,10 @@ function fakeRegistry(botIds: string[], config: Config): {
   return reg;
 }
 
-function setup(tokens: ResolvedAgentApiToken[]): string {
+function setup(
+  tokens: ResolvedAgentApiToken[],
+  opts: { exposeRunnerType?: boolean } = {},
+): string {
   tmpDir = mkdtempSync(join(tmpdir(), "torana-router-"));
   dbPath = join(tmpDir, "gateway.db");
   applyMigrations(dbPath);
@@ -56,6 +59,7 @@ function setup(tokens: ResolvedAgentApiToken[]): string {
   const bot = makeTestBotConfig("bot1");
   const config = makeTestConfig([bot]);
   config.agent_api.enabled = true;
+  config.agent_api.expose_runner_type = opts.exposeRunnerType === true;
 
   server = createServer({ port: 0, hostname: "127.0.0.1" });
   registerAgentApiHealthRoute(server.router, {
@@ -260,6 +264,53 @@ describe("/v1/bots listing is caller-scoped", () => {
     expect(r.status).toBe(200);
     const body = (await r.json()) as { bots: Array<{ bot_id: string }> };
     expect(body.bots.map((b) => b.bot_id)).toEqual(["bot1"]);
+  });
+});
+
+// `runner_type` leaks deployment shape — we hide it by default and
+// require an explicit `agent_api.expose_runner_type: true` opt-in.
+// See docs/agent-api.md "Security model".
+describe("/v1/bots runner_type exposure", () => {
+  const secret = "caller-runner-tok-9876";
+  const token: ResolvedAgentApiToken = {
+    name: "caller",
+    secret,
+    hash: hash(secret),
+    bot_ids: ["bot1"],
+    scopes: ["ask"],
+  };
+
+  test("default config: response omits runner_type entirely", async () => {
+    const base = setup([token]);
+    const r = await fetch(`${base}/v1/bots`, {
+      headers: { Authorization: `Bearer ${secret}` },
+    });
+    expect(r.status).toBe(200);
+    const body = (await r.json()) as {
+      bots: Array<{
+        bot_id: string;
+        supports_side_sessions: boolean;
+        runner_type?: string;
+      }>;
+    };
+    expect(body.bots).toHaveLength(1);
+    const item = body.bots[0]!;
+    expect(item.bot_id).toBe("bot1");
+    expect(item.supports_side_sessions).toBe(true);
+    expect("runner_type" in item).toBe(false);
+    expect(item.runner_type).toBeUndefined();
+  });
+
+  test("expose_runner_type=true: response includes runner_type", async () => {
+    const base = setup([token], { exposeRunnerType: true });
+    const r = await fetch(`${base}/v1/bots`, {
+      headers: { Authorization: `Bearer ${secret}` },
+    });
+    expect(r.status).toBe(200);
+    const body = (await r.json()) as {
+      bots: Array<{ bot_id: string; runner_type?: string }>;
+    };
+    expect(body.bots[0]!.runner_type).toBe("claude-code");
   });
 });
 

--- a/test/cli/bots.cmd.test.ts
+++ b/test/cli/bots.cmd.test.ts
@@ -38,6 +38,27 @@ describe("runBots list", () => {
     expect(r.stdout[3]).toMatch(/beta.*command.*no/);
   });
 
+  test("omits RUNNER column when no row carries runner_type", async () => {
+    // Default gateway config (`expose_runner_type: false`) → the field
+    // is missing from every list item, so the table drops the column
+    // rather than showing a useless empty string.
+    const client = clientStub({
+      listBots: async () => ({
+        bots: [
+          { bot_id: "alpha", supports_side_sessions: true },
+          { bot_id: "beta", supports_side_sessions: false },
+        ],
+      }),
+    });
+    const r = await runBots({ argv: [], action: "list" }, { client });
+    expect(r.exitCode).toBe(ExitCode.success);
+    expect(r.stdout[0]).toMatch(/^BOT_ID/);
+    expect(r.stdout[0]).not.toMatch(/RUNNER/);
+    expect(r.stdout[0]).toMatch(/ASK\?/);
+    expect(r.stdout[2]).toMatch(/^alpha\s+yes\s*$/);
+    expect(r.stdout[3]).toMatch(/^beta\s+no\s*$/);
+  });
+
   test("empty bot list prints helpful hint", async () => {
     const client = clientStub({
       listBots: async () => ({ bots: [] }),

--- a/test/cli/dispatch.test.ts
+++ b/test/cli/dispatch.test.ts
@@ -240,8 +240,12 @@ describe("torana bots list — subprocess dispatch", () => {
       ["bots", "list", "--server", base, "--token", secret],
     );
     expect(exitCode).toBe(0);
+    expect(stdout).toContain("BOT_ID");
     expect(stdout).toContain("bot1");
-    expect(stdout).toContain("claude-code");
+    // `runner_type` is hidden by default (`agent_api.expose_runner_type:
+    // false`), so the RUNNER column shouldn't render.
+    expect(stdout).not.toContain("RUNNER");
+    expect(stdout).not.toContain("claude-code");
   }, 15_000);
 
   test("--json mode parseable", async () => {

--- a/test/e2e/agent-api/_harness.ts
+++ b/test/e2e/agent-api/_harness.ts
@@ -210,6 +210,7 @@ export async function startE2E(opts: StartE2EOptions): Promise<E2EHarness> {
         max_body_bytes: 10 * 1024 * 1024,
         max_files_per_request: 5,
       },
+      expose_runner_type: false,
     },
     bots: [opts.botConfig],
   };

--- a/test/fixtures/bots.ts
+++ b/test/fixtures/bots.ts
@@ -95,6 +95,7 @@ export function makeTestConfig(
         max_body_bytes: 100 * 1024 * 1024,
         max_files_per_request: 10,
       },
+      expose_runner_type: false,
     },
     bots,
   };

--- a/test/integration/agent-api/send.round-trip.test.ts
+++ b/test/integration/agent-api/send.round-trip.test.ts
@@ -125,6 +125,7 @@ function makeConfig(opts: {
         max_body_bytes: 100 * 1024 * 1024,
         max_files_per_request: 10,
       },
+      expose_runner_type: false,
     },
     bots: [
       {

--- a/test/integration/round-trip.test.ts
+++ b/test/integration/round-trip.test.ts
@@ -111,6 +111,7 @@ function makeConfig(options: {
         max_body_bytes: 100 * 1024 * 1024,
         max_files_per_request: 10,
       },
+      expose_runner_type: false,
     },
     bots: options.bots.map((b) => ({
       id: b.id,

--- a/test/shutdown/shutdown.test.ts
+++ b/test/shutdown/shutdown.test.ts
@@ -110,6 +110,7 @@ function makeConfig(options: {
         max_body_bytes: 100 * 1024 * 1024,
         max_files_per_request: 10,
       },
+      expose_runner_type: false,
     },
     bots: options.bots.map((b) => ({
       id: b.id,

--- a/test/soak/agent-api.test.ts
+++ b/test/soak/agent-api.test.ts
@@ -225,6 +225,7 @@ async function startSoakHarness(cfg: SoakConfig): Promise<Harness> {
         max_body_bytes: 10 * 1024 * 1024,
         max_files_per_request: 5,
       },
+      expose_runner_type: false,
     },
     bots: [bot],
   };


### PR DESCRIPTION
## Summary

`GET /v1/bots` returned each bot's `runner_type` — `claude-code`,
`codex`, or `command` — to any bearer-token holder. That field leaks
deployment shape: it tells an attacker which side-channels (prompt
injection, tool-use abuse, command-shell access) are worth probing.

This PR drops the field from the default response and adds an opt-in
config flag for operators who actually need callers to branch on runner
kind.

## Why opt-in (not removed entirely, not kept as-is)

I traced every in-tree consumer of `runner_type` before deciding:

- **`src/cli/bots.ts`** — `torana bots list` displays it as a `RUNNER`
  table column for the operator. Cosmetic, not load-bearing for any
  routing.
- **`src/agent-api/client.ts`** — typed `BotsListItem.runner_type` (only
  used by the CLI above + downstream consumers).
- **`src/doctor.ts`** — never reads the field; only the test mocks
  include it.

No code path branches on the value. The CLI just renders it. So:

- **Removing entirely** would silently degrade the CLI for operators.
- **Keeping as-is** leaks deployment shape to every token holder by
  default, including bot-scoped tokens that don't need to know.
- **Opt-in via `agent_api.expose_runner_type` (default false)** is
  secure-by-default with a clear escape hatch. The CLI gracefully drops
  the column when the gateway hides the field (rather than showing an
  empty cell), so the operator UX degrades obviously when the flag is
  off — which is the correct cue to flip it on if they care.

## Changes

- `src/agent-api/router.ts` — `/v1/bots` handler reads
  `config.agent_api.expose_runner_type` and only emits `runner_type` when
  true.
- `src/config/schema.ts` — new `agent_api.expose_runner_type` boolean,
  default `false`.
- `src/agent-api/client.ts` — `BotsListItem.runner_type` is now
  `string | undefined`.
- `src/cli/bots.ts` — table drops the `RUNNER` column entirely when no
  row carries `runner_type`. Renders `—` if some rows carry it and
  others don't (defensive, shouldn't happen with this gateway).
- `docs/agent-api.md` — updated `/v1/bots` example, security model
  section, and YAML config snippet.
- `docs/cli.md` — `torana bots list` description.
- `CHANGELOG.md` — soft-break entry under `## [Unreleased]`.

## Tests

- `test/agent-api/router.test.ts` — new `runner_type exposure` describe
  with two cases (default omit / opt-in expose).
- `test/cli/bots.cmd.test.ts` — new test asserting the RUNNER column is
  dropped when no item carries the field.
- `test/cli/dispatch.test.ts` — existing CLI dispatch test updated to
  match the new default behavior.
- Test fixtures + integration harnesses updated to include the new
  required field.

## Test plan

- [x] `bun run typecheck` clean
- [x] `bun test` — 1145 pass, 0 fail
- [x] Prettier clean on touched files (no new style debt added)
- [x] Branched from `main`, not `rc.7/security-hardening`, so this
      lands independently for rc.8

🤖 Generated with [Claude Code](https://claude.com/claude-code)