### PR TITLE
fix(rc.9): dashboard proxy wedge after multi-hour uptime (#16)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,24 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 
 ## [Unreleased]
 
+### Fixed
+
+- **Dashboard proxy wedge after multi-hour uptime**
+  ([#16](https://github.com/jvbutterfield/torana/issues/16)). `/dashboard/*`
+  would stop responding after multi-hour uptime while every other torana
+  route stayed healthy. Two leaks fed it: (1) bun's HTTP client parked each
+  torana → upstream connection in its keepalive pool with no idle eviction,
+  so the pool grew monotonically until it hit an upstream cap and blocked
+  all new dashboard requests; (2) when a browser disconnected from a
+  long-lived response (the dashboard's SSE `EventSource`), the inbound
+  abort was not propagated to the upstream `fetch`, so the upstream socket
+  was held open until the upstream itself timed out. The proxy now sets
+  `Connection: close` on the upstream request (bounds pool growth on a
+  per-request basis — the proxy target is loopback by default, so the
+  per-request TCP setup is ~free) and threads `req.signal` into the
+  upstream `fetch` so client disconnects abort the upstream call. No
+  config change required.
+
 ## [1.0.0-rc.8] - 2026-04-27
 
 ### Added

--- a/src/main.ts
+++ b/src/main.ts
@@ -488,6 +488,8 @@ function registerFixedRoutes(
       //     mode.
       //   - Host: the fetch() rewrites this correctly; copying the gateway's
       //     Host to the backend confuses virtual-hosted upstreams.
+      //   - Connection: dropped here because we re-set it to "close" below;
+      //     a caller-supplied "Connection: keep-alive" must not win.
       // Retain everything else so request routing + Accept/Accept-Language
       // still work for the dashboard UI.
       const forwardedHeaders = new Headers(req.headers);
@@ -496,6 +498,7 @@ function registerFixedRoutes(
         "idempotency-key",
         "x-telegram-bot-api-secret-token",
         "host",
+        "connection",
       ];
       if (!forwardFull) {
         stripList.push("authorization", "cookie");
@@ -503,17 +506,32 @@ function registerFixedRoutes(
       for (const h of stripList) {
         forwardedHeaders.delete(h);
       }
+      // Force the upstream socket to close after this response. Without
+      // this, bun's HTTP client parks each torana → upstream connection in
+      // its keepalive pool; over multi-hour uptime the pool grows
+      // monotonically until it hits an upstream/anyio cap, at which point
+      // every new /dashboard/* request blocks waiting for a free slot.
+      // GH#16. The cost is one TCP setup per request, but the proxy target
+      // is loopback by default so RTT is ~zero; the wedge regression is
+      // the worse failure mode.
+      forwardedHeaders.set("connection", "close");
 
       try {
         // - redirect: "manual" stops fetch from following a backend Location:
         //   header. Without this the proxy can be used as an open redirect
         //   / SSRF stepping-stone into anywhere the gateway host can reach.
         //   Kept regardless of forward_full_request.
+        // - signal: req.signal propagates client-disconnect into the upstream
+        //   fetch. Critical for long-lived responses (SSE / EventSource):
+        //   without it, when the browser closes its EventSource the upstream
+        //   socket is held until the upstream itself times out, leaking pool
+        //   slots one-by-one until /dashboard/* wedges. GH#16.
         const proxyReq = new Request(backendUrl, {
           method: req.method,
           headers: forwardedHeaders,
           body: req.body,
           redirect: "manual",
+          signal: req.signal,
         });
         return await fetch(proxyReq);
       } catch {

--- a/test/main/dashboard-proxy.test.ts
+++ b/test/main/dashboard-proxy.test.ts
@@ -64,6 +64,7 @@ function mountProxy(forwardFull: boolean): void {
     "idempotency-key",
     "x-telegram-bot-api-secret-token",
     "host",
+    "connection",
   ];
   if (!forwardFull) {
     stripList.push("authorization", "cookie");
@@ -74,11 +75,13 @@ function mountProxy(forwardFull: boolean): void {
     const backendUrl = `${target}${rel}${url.search}`;
     const forwardedHeaders = new Headers(req.headers);
     for (const h of stripList) forwardedHeaders.delete(h);
+    forwardedHeaders.set("connection", "close");
     const proxyReq = new Request(backendUrl, {
       method: req.method,
       headers: forwardedHeaders,
       body: req.body,
       redirect: "manual",
+      signal: req.signal,
     });
     return await fetch(proxyReq);
   };
@@ -303,6 +306,108 @@ describe("dashboard proxy forward_full_request mode", () => {
     expect([0, 302]).toContain(r.status);
     expect(captured).not.toBeNull();
     expect(captured!.url).toContain("127.0.0.1");
+  });
+});
+
+describe("dashboard proxy connection lifetime (GH#16)", () => {
+  // Regression coverage for GH#16: `/dashboard/*` wedges after multi-hour
+  // uptime because (a) bun's HTTP client parks every upstream socket in the
+  // keepalive pool with no idle eviction, and (b) when the inbound client
+  // disconnects mid-stream (SSE EventSource reconnects), the upstream fetch
+  // is never aborted so the upstream socket is held open. The fix: send
+  // `Connection: close` upstream and propagate `req.signal` into the
+  // upstream fetch.
+
+  test("Connection: close is set on the upstream request (default mode)", async () => {
+    mountProxy(false);
+    await fetch(`http://127.0.0.1:${proxyServer.port}/dashboard/x`);
+    expect(captured).not.toBeNull();
+    expect(captured!.headers["connection"]?.toLowerCase()).toBe("close");
+  });
+
+  test("caller-supplied Connection: keep-alive is overridden to close", async () => {
+    // A caller cannot pin a keepalive on the upstream socket. Otherwise the
+    // pool-accumulation regression returns for any caller who sets the
+    // header (most HTTP libs default to keep-alive).
+    mountProxy(false);
+    await fetch(`http://127.0.0.1:${proxyServer.port}/dashboard/y`, {
+      headers: { Connection: "keep-alive" },
+    });
+    expect(captured).not.toBeNull();
+    expect(captured!.headers["connection"]?.toLowerCase()).toBe("close");
+  });
+
+  test("Connection: close is set in forward_full_request mode too", async () => {
+    mountProxy(true);
+    await fetch(`http://127.0.0.1:${proxyServer.port}/dashboard/api/login`, {
+      method: "POST",
+      body: "x",
+    });
+    expect(captured).not.toBeNull();
+    expect(captured!.headers["connection"]?.toLowerCase()).toBe("close");
+  });
+
+  test("client disconnect aborts the upstream fetch (SSE / long-lived response)", async () => {
+    // Replace the default capture upstream with one that keeps the response
+    // body open and exposes whether its inbound request was aborted by the
+    // proxy. This is the exact SSE shape from GH#16: headers flush
+    // immediately, body never ends, then the client goes away. Without
+    // `signal: req.signal` in the proxy, the upstream socket is held until
+    // the upstream times out — that's the leak.
+    await upstream.stop();
+    let upstreamAborted = false;
+    let upstreamSawRequest = false;
+    let resolveAbort!: () => void;
+    const upstreamAbortedPromise = new Promise<void>((resolve) => {
+      resolveAbort = resolve;
+    });
+    upstream = createServer({ port: 0, hostname: "127.0.0.1" });
+    const longLivedHandler = async (req: Request): Promise<Response> => {
+      upstreamSawRequest = true;
+      req.signal.addEventListener("abort", () => {
+        upstreamAborted = true;
+        resolveAbort();
+      });
+      const stream = new ReadableStream({
+        start(controller) {
+          controller.enqueue(new TextEncoder().encode(": hello\n\n"));
+          // intentionally never close — caller must abort.
+        },
+      });
+      return new Response(stream, {
+        status: 200,
+        headers: { "Content-Type": "text/event-stream" },
+      });
+    };
+    for (const m of ALL_METHODS) {
+      upstream.router.route(m, "/*", longLivedHandler);
+    }
+    mountProxy(false);
+
+    const ac = new AbortController();
+    const inflight = fetch(
+      `http://127.0.0.1:${proxyServer.port}/dashboard/api/pipeline/stream`,
+      { signal: ac.signal },
+    );
+    // Wait until the upstream has actually accepted the proxied request,
+    // otherwise aborting before the proxy hands off would not exercise
+    // signal propagation.
+    const start = Date.now();
+    while (!upstreamSawRequest && Date.now() - start < 2000) {
+      await new Promise((r) => setTimeout(r, 10));
+    }
+    expect(upstreamSawRequest).toBe(true);
+    ac.abort();
+    await inflight.catch(() => {});
+    // If `signal: req.signal` is missing from the proxy, the upstream never
+    // sees the abort and this race resolves to the rejection.
+    await Promise.race([
+      upstreamAbortedPromise,
+      new Promise((_, reject) =>
+        setTimeout(() => reject(new Error("upstream abort not seen")), 2000),
+      ),
+    ]);
+    expect(upstreamAborted).toBe(true);
   });
 });
 


### PR DESCRIPTION
## Summary

- Closes [#16](https://github.com/jvbutterfield/torana/issues/16): `/dashboard/*` wedges after multi-hour uptime while every other torana route stays healthy.
- Sets `Connection: close` on upstream requests so each connection is torn down after its response — bounds bun's HTTP-client keepalive pool on a per-request basis instead of waiting for an idle timeout that never fires. The proxy target is loopback by default, so the per-request TCP setup is ~free.
- Threads `req.signal` into the upstream `fetch` so client disconnects (the dashboard's SSE `EventSource` reconnect path is the main accumulator) abort the upstream call.
- Strips inbound `Connection` so callers cannot pin keep-alive on the upstream socket.

## Test plan

- [x] `bun test test/main/dashboard-proxy.test.ts` — 28 pass, including four new GH#16 regression cases (Connection: close in default + forward_full_request modes, caller keep-alive override, SSE client-disconnect → upstream-abort).
- [x] `bun run typecheck` clean.
- [x] `bun run format:check` clean.
- [x] CHANGELOG drift-guard passes.
- [ ] Watch /dashboard/* in production for >24h post-deploy without a wedge recurrence (cron probe at `tools/crons/torana-health-probe.sh` already in place).

🤖 Generated with [Claude Code](https://claude.com/claude-code)