### PR TITLE
rc.9: cut 1.0.0-rc.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 
 ## [Unreleased]
 
+## [1.0.0-rc.9] - 2026-05-07
+
 ### Changed
 
 - **Lazy first sendMessage so Telegram pushes a notification on each

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "torana",
-  "version": "1.0.0-rc.8",
+  "version": "1.0.0-rc.9",
   "description": "Open-source Telegram gateway for agent runtimes. Configuration-driven, any-runner, webhook or polling.",
   "license": "MIT",
   "author": "Jason Butterfield <jbutterfield@gmail.com>",


### PR DESCRIPTION
## Summary

Bumps `package.json` from `1.0.0-rc.8` → `1.0.0-rc.9` and inserts a `## [1.0.0-rc.9] - 2026-05-07` heading under `## [Unreleased]` so the two changes that landed since rc.8 attach to this version. Mirrors the rc.8 cut shape (`37bae2e`).

Two-change release:

- **Changed** — Lazy first sendMessage so Telegram pushes a notification on each reply ([#18](https://github.com/jvbutterfield/torana/pull/18)). Drops the eager `👀 thinking...` placeholder; the user-visible message is now sent fresh on the first text_delta (or at finalize for non-streaming runners). Edits don't push notifications; fresh sends do. Side benefits: empty responses no longer leave an orphan `thinking...` in chat, and we drop a redundant `editMessageText` per turn.
- **Fixed** — Dashboard proxy wedge after multi-hour uptime ([#16](https://github.com/jvbutterfield/torana/issues/16) via [#17](https://github.com/jvbutterfield/torana/pull/17)). bun's HTTP-client keepalive pool grew unbounded for the dashboard upstream, and SSE client disconnects weren't propagated to the upstream fetch. Now sets `Connection: close` upstream and threads `req.signal` into the upstream `fetch`. No config change required.

No breaking config changes since rc.8.

## Test plan

- [x] `bun run typecheck` clean.
- [x] `bun test` — 1267 pass / 0 fail / 13 skip across 120 files.
- [x] `bun run format:check` clean.
- [x] CHANGELOG drift-guard passes.
- [ ] After merge, tag `v1.0.0-rc.9` on the merge commit and push the tag.
- [ ] Watch /dashboard/* in production for >24h post-deploy without a wedge recurrence.
- [ ] Spot-check a Telegram reply on the deployed bot — confirm a push notification arrives when the response lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)